### PR TITLE
Hotfix define props with children

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -12,7 +12,7 @@ import { useStaticQuery, graphql } from "gatsby"
 import Header from "./header"
 import "./layout.css"
 
-const Layout: React.FC = ({ children }) => {
+const Layout = ({ children }: { children: React.ReactNode }) => {
     const data = useStaticQuery(graphql`
         query SiteTitleQuery {
             site {


### PR DESCRIPTION
## Description

`{ children }`에 대한 타입을 `ReactNode`로 지정