### PR TITLE
Update siteUrl in gatsby-meta-config.js

### DIFF
--- a/gatsby-meta-config.js
+++ b/gatsby-meta-config.js
@@ -2,5 +2,5 @@ module.exports = {
     title: `Gatsby’s TypeScript Starter`,
     description: `TypeScript version of the default Gatsby starter`,
     author: `@jongwooo`,
-    siteUrl: `https://typescriptstarter.gatsbyjs.io`,
+    siteUrl: `https://typescriptstarter.gtsb.io`,
 }


### PR DESCRIPTION
## Description

gatsby-meta-config.js의 siteUrl을 [https://typescriptstarter.gtsb.io](https://typescriptstarter.gtsb.io)로 수정함.
