### PR TITLE
docs: Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@
 
     Your site is now running at `http://localhost:8000`!
 
-    Note: You'll also see a second link: `http://localhost:8000/___graphql`. This is a tool you can use to experiment with querying your data. Learn more about using this tool in the [Gatsby tutorial](https://www.gatsbyjs.org/tutorial/part-five/#introducing-graphiql).
+    Note: You'll also see a second link: `http://localhost:8000/___graphql`. This is a tool you can use to experiment with querying your data. Learn more about using this tool in the [Gatsby tutorial](https://www.gatsbyjs.com/tutorial/part-five/#introducing-graphiql).
 
     Open the `gatsby-starter-typescript` directory in your code editor of choice and edit `src/pages/index.tsx`. Save your changes and the browser will update in real time!
 


### PR DESCRIPTION
## Description

`README.md`의 링크 중 Gatsby의 예전 도메인인 `.org`에서 새 도메인인 `.com`으로 변경함