### PR TITLE
refactor: Use setup-node to cache dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,24 +8,12 @@ jobs:
                 node-version: [14.x, 16.x]
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v1
+            - uses: actions/checkout@v3
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v1
+              uses: actions/setup-node@v3
               with:
                   node-version: ${{ matrix.node-version }}
-
-            - name: Get Yarn cache directory path
-              id: yarn-cache-dir-path
-              run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
-
-            - uses: actions/cache@v3
-              id: yarn-cache
-              with:
-                  path: |
-                      ${{ steps.yarn-cache-dir-path.outputs.dir }}
-                  key: ${{ runner.os }}-Node-v${{ matrix.node-version }}-Yarn-${{ hashFiles('**/yarn.lock') }}
-                  restore-keys: |
-                      ${{ runner.os }}-Node-v${{ matrix.node-version }}-Yarn-
+                  cache: yarn
 
             - uses: actions/cache@v3
               id: gatsby-cache

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -8,24 +8,12 @@ jobs:
                 node-version: [14.x, 16.x]
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v1
+            - uses: actions/checkout@v3
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v1
+              uses: actions/setup-node@v3
               with:
                   node-version: ${{ matrix.node-version }}
-
-            - name: Get Yarn cache directory path
-              id: yarn-cache-dir-path
-              run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
-
-            - uses: actions/cache@v3
-              id: yarn-cache
-              with:
-                  path: |
-                      ${{ steps.yarn-cache-dir-path.outputs.dir }}
-                  key: ${{ runner.os }}-Node-v${{ matrix.node-version }}-Yarn-${{ hashFiles('**/yarn.lock') }}
-                  restore-keys: |
-                      ${{ runner.os }}-Node-v${{ matrix.node-version }}-Yarn-
+                  cache: yarn
 
             - name: Install dependencies
               run: yarn install


### PR DESCRIPTION
## Description

기존  [actions/cache](https://github.com/actions/cache)룰 통하여 사용하던 `의존성 캐싱` 기능을 [actions/setup-node](https://github.com/actions/setup-node)에 내장된 기능으로 대체함.
