### PR TITLE
chore: Bump @babel/preset-typescript from 7.18.6 to 7.21.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@babel/preset-typescript": "^7.18.6",
+    "@babel/preset-typescript": "^7.21.0",
     "@types/jest": "^29.4.0",
     "@types/react": "^18.0.28",
     "@types/react-test-renderer": "^18.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1420,7 +1420,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/preset-typescript@npm:^7.18.6":
+"@babel/preset-typescript@npm:^7.18.6, @babel/preset-typescript@npm:^7.21.0":
   version: 7.21.0
   resolution: "@babel/preset-typescript@npm:7.21.0"
   dependencies:
@@ -7942,7 +7942,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "gatsby-starter-typescript@workspace:."
   dependencies:
-    "@babel/preset-typescript": ^7.18.6
+    "@babel/preset-typescript": ^7.21.0
     "@types/jest": ^29.4.0
     "@types/react": ^18.0.28
     "@types/react-test-renderer": ^18.0.0


### PR DESCRIPTION
## Description

[babel/babel@v7.21.0](https://github.com/babel/babel/releases/tag/v7.21.0) release에 따라 `@babel/preset-typescript`를 v7.18.6에서 v7.21.0으로 업데이트함.
